### PR TITLE
Fix check plugin command

### DIFF
--- a/dokku
+++ b/dokku
@@ -58,7 +58,7 @@ if [[ $(id -un) != "dokku" ]] && [[ ! $1 =~ plugin:* ]]; then
   exit $?
 fi
 
-if [[ $(id -un) != "root" && $1 =~ plugin:.* ]]; then
+if [[ $(id -un) != "root" && $1 =~ ^plugin:.* ]]; then
   dokku_log_fail "plugin:* commands must be run as root"
 fi
 

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -2,6 +2,7 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/apps/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 git_build_app_repo() {
   verify_app_name "$1"
@@ -31,7 +32,7 @@ git_build_app_repo() {
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && ! grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV > /dev/null 2>&1; then
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get $APP BUILDPACK_URL) ]]; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -31,7 +31,7 @@ git_build_app_repo() {
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && "$(grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV)"; then
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -31,7 +31,7 @@ git_build_app_repo() {
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]]; then
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ "$(grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV)" ]]; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -31,7 +31,7 @@ git_build_app_repo() {
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && ! $(grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV); then
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && ! grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV > /dev/null 2>&1; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -31,7 +31,7 @@ git_build_app_repo() {
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ "$(grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV)" ]]; then
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && "$(grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV)"; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -31,7 +31,7 @@ git_build_app_repo() {
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV; then
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && ! $(grep -q BUILDPACK_URL $DOKKU_ROOT/$APP/ENV); then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else


### PR DESCRIPTION
While adding `:plugin:install` capability to the `dokku-elasticsearch` plugin, I noticed that this check prevents my unit tests to run.

This PR fixes the issue, while maintaining the ìd` check when installing dokku plugins.
